### PR TITLE
Add extern "C" to headers

### DIFF
--- a/libmctp-serial.h
+++ b/libmctp-serial.h
@@ -3,6 +3,10 @@
 #ifndef _LIBMCTP_SERIAL_H
 #define _LIBMCTP_SERIAL_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "libmctp.h"
 
 struct mctp_binding_serial;
@@ -15,5 +19,9 @@ int mctp_serial_read(struct mctp_binding_serial *serial);
 int mctp_serial_open_path(struct mctp_binding_serial *serial,
 		const char *path);
 void mctp_serial_open_fd(struct mctp_binding_serial *serial, int fd);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _LIBMCTP_SERIAL_H */

--- a/libmctp.h
+++ b/libmctp.h
@@ -3,6 +3,10 @@
 #ifndef _LIBMCTP_H
 #define _LIBMCTP_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 
 typedef uint8_t mctp_eid_t;
@@ -89,5 +93,9 @@ void mctp_set_alloc_ops(void *(*alloc)(size_t),
 		void (*free)(void *),
 		void *(realloc)(void *, size_t));
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _LIBMCTP_H */


### PR DESCRIPTION
Add extern "C" to headers so that they can be included by cpp code.

Signed-off-by: Deepak Kodihalli <dkodihal@in.ibm.com>